### PR TITLE
Cache input pads to remove iteration in demand

### DIFF
--- a/test/membrane_funnel_plugin/membrane_funnel_test.exs
+++ b/test/membrane_funnel_plugin/membrane_funnel_test.exs
@@ -27,6 +27,9 @@ defmodule Membrane.FunnelTest do
 
     :ok = Testing.Pipeline.play(pipeline)
 
+    assert_receive {Membrane.Testing.Pipeline, ^pipeline,
+                    {:playback_state_changed, :prepared, :playing}}
+
     data
     |> Enum.flat_map(&[&1, &1])
     |> Enum.each(fn payload ->
@@ -35,5 +38,10 @@ defmodule Membrane.FunnelTest do
 
     assert_end_of_stream(pipeline, :sink)
     refute_sink_buffer(pipeline, :sink, _buffer, 0)
+
+    Membrane.Pipeline.stop_and_terminate(pipeline)
+
+    assert_receive {Membrane.Testing.Pipeline, ^pipeline,
+                    {:playback_state_changed, :prepared, :stopped}}
   end
 end


### PR DESCRIPTION
When analyzing process activity in the `Membrane.RTC.Engine`, I find that `:ice_funnel` processes consistently have the greatest reduction count. It's the most active element, receiving buffers from multiple sources, so there's no surprise there.

I noticed that in `handle_demand` it's doing a double enumeration, first on all pads, then on all discovered input pads. Since this list only ever changes in `handle_pad_added` or `handle_pad_removed`, I thought that caching the list of demands might reduce some of the CPU cycles spent in these elements. Not a tremendous savings, but maybe it'll have *some* benefit.