### PR TITLE
Fix Dialyzer warning blocking v0.9.3 release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,6 +12,8 @@ jobs:
 
   lint:
     uses: membraneframework/membrane_actions/.github/workflows/lint.yml@main
+    with:
+      dialyzer: false
 
   test:
     uses: membraneframework/membrane_actions/.github/workflows/test.yml@main


### PR DESCRIPTION
## Root cause

The v0.9.3 Release run ([28377747419](https://github.com/membraneframework/membrane_funnel_plugin/actions/runs/28377747419)) failed at `lint / lint` → **Run Dialyzer** with:

```
:dialyzer.run error: Analysis failed with error:
No .beam files to analyze (no --src specified?)
Halting VM with exit status 1
```

`Membrane.Funnel` and `Membrane.Funnel.NewInputEvent` were incorporated into `membrane_core` (membraneframework/membrane_core#922). Accordingly, this package guards its module definitions with `Code.ensure_loaded?/1` and only defines them when the running `membrane_core` does **not** already provide them. Removing the guard is not an option — it produces `redefining module Membrane.Funnel` warnings that fail `--warnings-as-errors`.

When built against a `membrane_core` that ships `Funnel` (the locked `1.3.4`), the guard skips both modules, so `membrane_funnel_plugin` compiles to **zero modules**. Dialyxir then has no beams to analyze and aborts, failing `lint` and skipping `hex_publish`.

This is why `ci.yml` already sets `dialyzer: false` for its `lint` job. The Release workflow (added later) was missing the same override, so Dialyzer ran on the empty app and failed.

## Fix

Mirror `ci.yml`: pass `dialyzer: false` to the `lint` job in `release.yml`. There is no code/`@spec` to correct — the package legitimately has no modules of its own once `membrane_core` provides `Funnel`, so Dialyzer is inapplicable here (as CI already reflects).

## Verification (local, Elixir 1.19.5 / OTP 28, membrane_core 1.3.4)

- Reproduced the exact CI failure: `mix dialyzer` → `No .beam files to analyze`.
- `mix compile --force --warnings-as-errors` → clean.
- `mix test` → 1 test, 0 failures.

Note: the v0.9.3 tag still points at the old commit; re-tagging / version bump is left to a maintainer.